### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 
 jobs:
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/g1ibby/homellm/security/code-scanning/1](https://github.com/g1ibby/homellm/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Based on the workflow's operations, the minimal required permission is likely `contents: read`, as the workflow checks out the repository and deploys using Docker Compose. No write permissions appear to be necessary.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
